### PR TITLE
Fix mapnew() usage in dpp#ext#lazy#_generate_dummy_mappings

### DIFF
--- a/autoload/dpp/ext/lazy.vim
+++ b/autoload/dpp/ext/lazy.vim
@@ -297,7 +297,7 @@ function dpp#ext#lazy#_generate_dummy_mappings(plugin) abort
   let items =
         \ on_map->type() == v:t_string ? [[['n', 'x', 'o'], [on_map]]] :
         \ on_map->type() == v:t_dict ?
-        \ on_map->mapnew({ _, val -> [val[0]->split('\zs'),
+        \ on_map->items()->mapnew({ _, val -> [val[0]->split('\zs'),
         \       val[1]->dpp#util#_convert2list()]}) :
         \ on_map->mapnew({ _, val -> type(val) == v:t_list ?
         \       [val[0]->split('\zs'), val[1:]] :


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in commit e19c8e01 where using `mapnew()` on a dictionary caused an error.

## Problem

In commit e19c8e01, the code was changed to use `mapnew()` instead of `copy()->map()`. However, `mapnew()` cannot be called directly on a dictionary type - it requires a list.

**Error:**
```
Vim(for):E1098: String, List or Blob required (code: 0)
```

This error occurred at line 17 of `dpp#ext#lazy#_generate_dummy_mappings` when `makeState` was executed.

```
[denops] Failed to load file '/home/yasunori/.config/dpp/config.ts': Error: Failed to call 'dpp#ext#lazy#_generate_dummy_mappings' in Neovim: function dpp#ext#lazy#_generate_dummy_mappings, l
ine 17: Vim(for):E1098: String, List or Blob required (code: 0)
[denops] Failed to handle message 2,invoke,dispatch,dpp,makeState,/home/yasunori/.cache/dpp,/home/yasunori/.config/dpp/config.ts,nvim,[object Object] Error: Failed to call 'makeState' API in
'dpp': Error: Failed to call 'dpp#ext#lazy#_generate_dummy_mappings' in Neovim: function dpp#ext#lazy#_generate_dummy_mappings, line 17: Vim(for):E1098: String, List or Blob required (code: 0
)
[denops]     at Neovim.call (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/host/nvim.ts:68:15)
[denops]     at eventLoopTick (ext:core/01_core.js:179:7)
[denops]     at async Object.callback (file:///home/yasunori/.cache/deno/import_map_importer/00/ea/00ea1c96f3dc0bf16aed09a21cc569a8f0a671e34778c0a938aca2dbb902e8fc-main.ts:99:33)
[denops]     at async makeState (file:///home/yasunori/.config/dpp/helper/lazy.ts:44:10)
[denops]     at async Config.config (file:///home/yasunori/.config/dpp/config.ts#1249.721108:71:24)
[denops]     at async file:///home/yasunori/.cache/deno/import_map_importer/e8/c0/e8c0c1a6a716ff5b9c1d0f93f455c06d4ad6d5583528b0875b339c854992cd52-app.ts:111:32
[denops]     at async Lock.lock (https://jsr.io/@core/asyncutil/1.2.0/lock.ts:48:14)
[denops]     at async Object.makeState (file:///home/yasunori/.cache/deno/import_map_importer/e8/c0/e8c0c1a6a716ff5b9c1d0f93f455c06d4ad6d5583528b0875b339c854992cd52-app.ts:104:7)
[denops]     at async Plugin.call (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/plugin.ts:95:14)
[denops]     at async Service.#dispatch (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:117:12)
[denops]     at Plugin.call (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/plugin.ts:100:13)
[denops]     at eventLoopTick (ext:core/01_core.js:179:7)
[denops]     at async Service.#dispatch (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:117:12)
[denops]     at async Service.dispatch (file:///home/yasunori/.cache/dpp/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:123:14)
[denops]     at async dispatch (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.1/dispatcher.ts:36:12)
[denops]     at async Session.#dispatch (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.1/session.ts:255:22)
[denops]     at async Session.#handleNotificationMessage (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.1/session.ts:310:25)
```


## Solution

When handling dictionary type `on_map`, convert it to a list first using `items()` before calling `mapnew()`:

```vim
on_map->items()->mapnew({ _, val -> ... })
```

## Testing

- Verified that `makeState` completes successfully with this fix
- Tested with the configuration that previously caused the error